### PR TITLE
Make batch requests/queries to API and database to improve performance

### DIFF
--- a/src/Dao/EnwikiDao.php
+++ b/src/Dao/EnwikiDao.php
@@ -47,6 +47,24 @@ class EnwikiDao extends AbstractDao {
 
 
 	/**
+	 * Get details on multiple revisions
+	 *
+	 * @param $diffs array Revision IDs
+	 * @return array full revision rev_id, rev_user, rev_usertext, user_editcount and user_name of the revision
+	 */
+	public function getRevisionDetailsMulti( $diffs ) {
+		$query = self::concat(
+			'SELECT r.rev_id, r.rev_user, r.rev_user_text, u.user_editcount, u.user_name',
+			'FROM revision r',
+			'LEFT JOIN user u ON r.rev_user = u.user_id',
+			'WHERE r.rev_id IN (' . implode( ',', array_fill( 0, count( $diffs ), '?' ) ) . ')'
+		);
+		$result = $this->fetchAll( $query, $diffs );
+		return $result;
+	}
+
+
+	/**
 	 * Get editor details
 	 *
 	 * @param $diff int Diff revision ID
@@ -71,6 +89,35 @@ class EnwikiDao extends AbstractDao {
 			$data['editcount'] = $result['user_editcount'];
 		}
 		return $data;
+	}
+
+
+	/**
+	 * Determine which of the given pages are dead
+	 *
+	 * @param $titles array Page titles
+	 * @return array the pages that are dead
+	 */
+	public function getDeadPages( $titles ) {
+		if ( !$titles ) {
+			return array();
+		}
+		$titles = array_map( 'urlencode', $titles );
+		$url = $this->wikipedia . '/w/api.php?action=query&format=json&titles=' . join( '|', $titles ) . '&formatversion=2';
+		$ch = curl_init();
+		curl_setopt( $ch, CURLOPT_URL, $url );
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, TRUE );
+		$result = curl_exec( $ch );
+		$json = json_decode( $result );
+		$deadPages = array();
+		foreach ( $json->query->pages as $p ) {
+			if ( isset( $p->missing ) ) {
+				// Please note that this returns a false positive when the user account has a global User page and
+				// not a local one
+				$deadPages[] = $p->title;
+			}
+		}
+		return $deadPages;
 	}
 
 


### PR DESCRIPTION
From my testing, this improves load time dramatically. Everything but querying for WikiProjects is done en masse. The biggest slowdown was the API, so checking for dead links in only three different requests makes a big difference, it seems.

This PR I'm not super confident in, but it works :) I know I need to use prepared statements in `getRevisionDetailsMulti`, but I could not get it to work for some reason. Meanwhile `handleGet` looks very messy, but this sequence of loops is necessary to ensure we have all the data we need before updating the view – and doing so in a way that is performant.